### PR TITLE
fix(ci): upgrade to pnpm 11 for npm audit API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.19.0
+          version: 11.14.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.19.0
+          version: 11.14.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Tactical RMM is a remote monitoring and management tool, built with Django and V
 This repo uses **pnpm** with a committed lockfile and supply-chain controls in [`pnpm-workspace.yaml`](pnpm-workspace.yaml) (see [SECURITY.md](SECURITY.md)). After clone:
 
 ```bash
-corepack enable && corepack prepare pnpm@10.19.0 --activate
+corepack enable && corepack prepare pnpm@11.14.0 --activate
 pnpm install --frozen-lockfile
 pnpm run audit:supply-chain
 pnpm run build

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ This repository uses defenses against npm supply-chain worms such as **Mini Shai
 - **pnpm only** — `packageManager`, `engines.pnpm`, and `pnpm-lock.yaml` enforce a single package manager. Enable Corepack so `npm install` / `yarn install` are rejected in this repo (see below). We do **not** use a `preinstall` script: that would run when end users install the published node via npm in n8n.
 - **Frozen lockfile** — `pnpm-lock.yaml` is committed; CI uses `pnpm install --frozen-lockfile`.
 - **pnpm workspace config** — supply-chain settings live in `pnpm-workspace.yaml` (pnpm 10+ ignores `package.json` → `pnpm`).
-- **Blocked install scripts** — only packages in `pnpm-workspace.yaml` → `onlyBuiltDependencies` may run lifecycle scripts (currently `isolated-vm` for dev tooling). `strictDepBuilds: true` fails on unreviewed scripts.
+- **Blocked install scripts** — only packages with `allowBuilds: true` in `pnpm-workspace.yaml` may run lifecycle scripts (currently `isolated-vm` for dev tooling). `strictDepBuilds: true` fails on unreviewed scripts.
 - **Blocklist scan** — `pnpm run audit:supply-chain` checks the lockfile against `security/compromised-packages.json` and validates pnpm config.
 - **Delayed updates** — `minimumReleaseAge` (24h, strict) reduces exposure to freshly published malicious versions.
 - **No exotic transitive deps** — `blockExoticSubdeps` blocks git/tarball transitive resolutions.
@@ -21,7 +21,7 @@ This repository uses defenses against npm supply-chain worms such as **Mini Shai
 
    ```bash
    corepack enable
-   corepack prepare pnpm@10.19.0 --activate
+   corepack prepare pnpm@11.14.0 --activate
    pnpm install --frozen-lockfile
    ```
 

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "access": "public",
     "provenance": true
   },
-  "packageManager": "pnpm@10.19.0",
+  "packageManager": "pnpm@11.14.0",
   "engines": {
     "node": ">=22.22.3",
-    "pnpm": ">=10.19.0"
+    "pnpm": ">=11.14.0"
   },
   "volta": {
     "node": "22.22.3",
-    "pnpm": "10.19.0"
+    "pnpm": "11.14.0"
   },
   "main": "index.js",
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,10 +7,8 @@ overrides:
   uuid: '11.1.1'
   n8n-workflow: '2.22.3'
 
-onlyBuiltDependencies:
-  - isolated-vm
-
-ignoredBuiltDependencies: []
+allowBuilds:
+  isolated-vm: true
 
 minimumReleaseAge: 1440
 minimumReleaseAgeStrict: true

--- a/scripts/check-supply-chain.mjs
+++ b/scripts/check-supply-chain.mjs
@@ -20,7 +20,7 @@ const REQUIRED_WORKSPACE_SETTINGS = [
 	'minimumReleaseAgeStrict:',
 	'blockExoticSubdeps:',
 	'strictDepBuilds:',
-	'onlyBuiltDependencies:',
+	'allowBuilds:',
 	'overrides:',
 ];
 
@@ -45,7 +45,7 @@ function verifyPnpmOnlyRepository() {
 		const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 		const pm = pkg.packageManager ?? '';
 		if (!pm.startsWith('pnpm@')) {
-			errors.push('package.json "packageManager" must pin pnpm (e.g. pnpm@10.19.0)');
+			errors.push('package.json "packageManager" must pin pnpm (e.g. pnpm@11.14.0)');
 		}
 		if (!pkg.engines?.pnpm) {
 			errors.push('package.json engines.pnpm is required — rejects installs with wrong package manager');
@@ -96,27 +96,38 @@ function verifyActivePnpmConfig() {
 	const errors = [];
 
 	try {
-		const config = execSync('pnpm config list', {
+		const raw = execSync('pnpm config list', {
 			cwd: root,
 			encoding: 'utf8',
 			stdio: ['ignore', 'pipe', 'pipe'],
 		});
 
-		const required = [
-			['minimum-release-age=1440', 'minimumReleaseAge (24h delay) is not active'],
-			['minimum-release-age-strict=true', 'minimumReleaseAgeStrict is not active'],
-			['block-exotic-subdeps=true', 'blockExoticSubdeps is not active'],
-			['strict-dep-builds=true', 'strictDepBuilds is not active'],
-			['only-built-dependencies[]=isolated-vm', 'onlyBuiltDependencies allowlist missing isolated-vm'],
-		];
-
-		for (const [needle, message] of required) {
-			if (!config.includes(needle)) {
-				errors.push(message);
-			}
+		let config;
+		try {
+			config = JSON.parse(raw);
+		} catch {
+			errors.push('pnpm config list did not return JSON — expected pnpm 11+');
+			return errors;
 		}
 
-		if (!config.includes('lodash=') || !config.includes('uuid=')) {
+		if (config.minimumReleaseAge !== 1440) {
+			errors.push('minimumReleaseAge (24h delay) is not active');
+		}
+		if (config.minimumReleaseAgeStrict !== true) {
+			errors.push('minimumReleaseAgeStrict is not active');
+		}
+		if (config.blockExoticSubdeps !== true) {
+			errors.push('blockExoticSubdeps is not active');
+		}
+		if (config.strictDepBuilds !== true) {
+			errors.push('strictDepBuilds is not active');
+		}
+		if (config.allowBuilds?.['isolated-vm'] !== true) {
+			errors.push('allowBuilds allowlist missing isolated-vm');
+		}
+
+		const overrides = config.overrides ?? {};
+		if (!overrides.lodash || !overrides.uuid) {
 			errors.push('pnpm overrides for lodash/uuid are not active — check pnpm-workspace.yaml');
 		}
 	} catch (error) {


### PR DESCRIPTION
npm retired the legacy security/audits endpoints (HTTP 410). pnpm 11 uses the bulk advisories API and requires allowBuilds instead of onlyBuiltDependencies.